### PR TITLE
Convert "SHOW TABLES" to instead query information_schema.tables...

### DIFF
--- a/src/metabase/driver/arrow_flight_sql.clj
+++ b/src/metabase/driver/arrow_flight_sql.clj
@@ -163,13 +163,13 @@
 ;; Custom Schema Sync Implementations
 ;; ----------------------------------------------------------------
 
-;; List tables by executing the "SHOW TABLES" command.
+;; List tables by querying information_schema.tables.
 (defmethod driver/describe-database :arrow-flight-sql
   [driver database]
   (let [spec (sql-jdbc.conn/connection-details->spec :arrow-flight-sql (:details database))]
     (with-open [conn (jdbc/get-connection spec)]
       (let [rows (jdbc/query {:connection conn}
-                             ["SHOW TABLES"]
+                             ["SELECT table_name, table_schema FROM information_schema.tables"]
                              {:identifiers str/lower-case})
             formatted (->> rows
                            (filter #(not= (str/lower-case (:table_schema %)) "information_schema"))


### PR DESCRIPTION
Hi @J0hnG4lt !  

I've been attempting to use your Metabase driver with GizmoSQL (an Arrow Flight SQL Server with a DuckDB back-end) - see: https://github.com/gizmodata/gizmosql

It didn't quite work well with: "SHOW TABLES" - but using a more ANSI-compliant method for getting tables (information_schema.tables) seems to work ok.

I was prompted to try using this driver from and issue that @mikeispanda had opened in the GizmoSQL repo:
https://github.com/gizmodata/gizmosql/issues/34

Is this change ok?

Thank you.