### PR TITLE
chore: upgrade Metabase to v0.62.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: metabase/metabase
+        # Pin to the Metabase version the driver ships against. Building against
+        # an unpinned master breaks whenever upstream restructures modules/drivers
+        # (e.g. sqlite/druid were removed from modules/drivers after v0.62), which
+        # ci/deps.edn still references as :local/root siblings.
+        ref: v0.62.4
         path: metabase
 
     - name: Checkout driver code

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     restart: "no"
 
   metabase:
-    image: metabase/metabase:v0.57.7
+    image: metabase/metabase:v0.62.4
     container_name: metabase
     hostname: metabase
     depends_on:


### PR DESCRIPTION
## Summary
Upgrades the Metabase image from **v0.57.7 → v0.62.4** (latest OSS release).

```diff
-    image: metabase/metabase:v0.57.7
+    image: metabase/metabase:v0.62.4
```

## Testing
Ran the full end-to-end flow fresh against v0.62.4 — all green:

| Check | Result |
|---|---|
| `arrow-flight-sql` driver load | ✅ `Registered driver :arrow-flight-sql (parents: [:sql-jdbc])` |
| DB connections | ✅ GizmoSQL + Spice, engine `arrow-flight-sql` |
| Schema sync | ✅ GizmoSQL 13 tables, Spice 1 table |
| Dashboard | ✅ 32 cards, 5 filters |
| All dashboard cards | ✅ **32/32** return `completed` with data |
| Field filters (all 5) | ✅ Order Status, Country, Department, Marketing Channel, Date Range |
| Connection pool health | ✅ No pool-invalidation warnings; pool stable |

## Known caveat (pre-existing, not introduced here)
Fingerprinting the Spice `yellow_taxis` table logs a `WARN: Unsupported ArrowType Utf8View`. Metabase's fingerprint query wraps text columns in `SUBSTRING(col,1,1234)`, and Spice's DuckDB returns that expression as Arrow `Utf8View`, which the bundled Arrow Flight SQL JDBC driver (18.2.0) can't map. It is a warning only — sync completes, the raw column reads fine, and no dashboard card is affected. This is independent of the Metabase version (Arrow type mapping lives in the JDBC driver jar) and would require a separate driver-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)